### PR TITLE
Fix ul shift at 768px

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -133,3 +133,8 @@ html {
     transform: none !important;
   }
 }
+@media (min-width: 768px) {
+  .md\:pt-6 {
+    padding-left: 2.1rem;
+  }
+}


### PR DESCRIPTION
Fix media query issue causing ul misalignment at 768px. This commit resolves the problem of the unordered list (ul) shifting incorrectly at the breakpoint of 768px. The alignment issue has been fixed, ensuring that the ul displays correctly at all screen sizes. You can view the changes made in this commit at the following fork: https://blablaconf-com-pi.vercel.app/