### PR TITLE
Fix ul shift at 768px

### DIFF
--- a/components/agenda/days-menu.tsx
+++ b/components/agenda/days-menu.tsx
@@ -107,7 +107,7 @@ export const DaysMenu = ({
       className="sticky md:top-2 top-0  md:h-full h-fit overflow-scroll md:overflow-visible scroll-smooth md:bg-transparent  bg-white/60 z-40 hidden md:block xl:ml-0 lg:ml-5"
     >
       <div className="md:mt-8 mt-1">
-        <ul className="md:pt-6 pt-3 relative md:border-l-[1px] md:border-t-[0px] border-t-[1px] border-l-[0px] border-white/80 pr-12 h-fit  w-fit flex flex-row md:flex-col  ">
+        <ul className="md:pt-6 pt-3 relative md:border-l-[1px] md:border-t-[0px] border-t-[1px] border-l-[0px] border-white/80 pr-12 h-fit  w-fit flex flex-row md:flex-col daysulpadding ">
           {days.map((day, index) => {
             return (
               <Day

--- a/components/agenda/days-menu.tsx
+++ b/components/agenda/days-menu.tsx
@@ -107,7 +107,7 @@ export const DaysMenu = ({
       className="sticky md:top-2 top-0  md:h-full h-fit overflow-scroll md:overflow-visible scroll-smooth md:bg-transparent  bg-white/60 z-40 hidden md:block xl:ml-0 lg:ml-5"
     >
       <div className="md:mt-8 mt-1">
-        <ul className="md:pt-6 pt-3 relative md:border-l-[1px] md:border-t-[0px] border-t-[1px] border-l-[0px] border-white/80 pr-12 h-fit  w-fit flex flex-row md:flex-col daysulpadding ">
+        <ul className="md:pt-6 pt-3 relative md:border-l-[1px] md:border-t-[0px] border-t-[1px] border-l-[0px] border-white/80 pr-12 h-fit w-fit flex flex-row md:flex-col lg:pl-0 md:pl-8">
           {days.map((day, index) => {
             return (
               <Day

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -134,7 +134,7 @@ html {
   }
 }
 @media (min-width: 768px) {
-  .md\:pt-6 {
-    padding-left: 2.1rem;
-  }
+ .daysulpadding {
+  padding-left: 2.1rem; 
+}
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -133,8 +133,4 @@ html {
     transform: none !important;
   }
 }
-@media (min-width: 768px) {
- .daysulpadding {
-  padding-left: 2.1rem; 
-}
-}
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -133,3 +133,8 @@ html {
     transform: none !important;
   }
 }
+@media (min-width: 768px) {
+  .md\:pt-6 {
+    padding-left: 2.1rem;
+  }
+}


### PR DESCRIPTION
Fix media query issue causing ul misalignment at 768px. This commit resolves the problem of the unordered list (ul) shifting incorrectly at the breakpoint of 768px. The alignment issue has been fixed, ensuring that the ul displays correctly at all screen sizes. You can view the changes made in this commit at the following fork: https://blablaconf-com-pi.vercel.app/